### PR TITLE
Fixed issue 36:  Illegal argument: character must be non-negative

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export const activeFileIsValid = (document: vscode.TextDocument | undefined, edi
  * @return the corresponding Range of the given message
  */
 export const getMessageRange = (message: IMessage): vscode.Range => {
-	const startPosition = new vscode.Position((message.firstLine ?? message.lastLine) - 1, message.hiliteStart - 1);
+	const startPosition = new vscode.Position((message.firstLine ?? message.lastLine) - 1, Math.max(message.hiliteStart - 1, 0));
 	const stopPosition = new vscode.Position(message.lastLine - 1, message.hiliteStart - 1 + message.hiliteLength);
 	return new vscode.Range(startPosition, stopPosition);
 };


### PR DESCRIPTION
If the W3C violation occurs in the first character of the file, e.g. if the file references a legacy doctype, `message.hiliteStart` will be 0, and `message.hiliteStart-1` will be negative, causing the error `Illegal argument: character must be non-negative`. This was a quick fix: instead of passing `message.hiliteStart-1` directly as a parameter of `vscode.Position`, pass `Math.max(message.hiliteStart-1,0)`, which forces the character to be nonnegative.